### PR TITLE
ci : Modify default permissions granted to GITHUB_TOKEN in workflows

### DIFF
--- a/.github/workflows/e2e-report.yml
+++ b/.github/workflows/e2e-report.yml
@@ -6,6 +6,9 @@ on:
 env:
   ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
 
+permissions:
+  contents: read
+
 jobs:
   generate_report:
     name: Generate E2E report

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,6 +6,9 @@ on:
 env:
   ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
 
+permissions:
+  contents: read
+
 jobs:
   bootstrap-CI-test-run:
     name: Bootstrap CI test run (#${{ github.event.client_payload.pr }})

--- a/.github/workflows/javascript.yml
+++ b/.github/workflows/javascript.yml
@@ -2,6 +2,9 @@ name: Check JS code
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   main:
     name: Check


### PR DESCRIPTION
Related to https://github.com/eclipse/jkube/issues/1767

Set content write to read in GitHub workflows in order to limit permissions granted to GitHub token used in workflows

Signed-off-by: Rohan Kumar <rohaan@redhat.com>