### PR TITLE
ci : Add Harden Runner GitHub action GitHub Action workflows

### DIFF
--- a/.github/workflows/javascript.yml
+++ b/.github/workflows/javascript.yml
@@ -1,6 +1,6 @@
 name: Check JS code
 
-on: [push]
+on: [push, pull_request]
 
 permissions:
   contents: read

--- a/.github/workflows/javascript.yml
+++ b/.github/workflows/javascript.yml
@@ -10,6 +10,14 @@ jobs:
     name: Check
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@18bf8ad2ca49c14cbb28b91346d626ccfb00c518
+        with:
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            github.com:443
+            registry.npmjs.org:443
       - name: Checkout
         uses: actions/checkout@v3
       - name: Setup Node


### PR DESCRIPTION
# Description

Related to https://github.com/eclipse/jkube/issues/1767

+ Add Harden Runner GitHub action
   - [StepSecurity report for Javascript action ](https://app.stepsecurity.io/github/jkubeio/ci/actions/runs/3937787465)
+ Use latest commit SHA for Harden Runner

Signed-off-by: Rohan Kumar <rohaan@redhat.com>