### PR TITLE
chore (deps) : bump actions/cache to `69d9d449aced6a2ede0bc19182fadc3a0a42d2b0` revision (#243)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -22,7 +22,7 @@ jobs:
           java-version: '11'
           distribution: 'temurin'
       - name: Cache .m2 and JKube
-        uses: actions/cache@v3
+        uses: actions/cache@69d9d449aced6a2ede0bc19182fadc3a0a42d2b0
         with:
           path: |
             ${{ github.workspace }}/jkube
@@ -54,7 +54,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Restore cache .m2 and JKube
-        uses: actions/cache@v2
+        uses: actions/cache@69d9d449aced6a2ede0bc19182fadc3a0a42d2b0
         with:
           path: |
             ${{ github.workspace }}/jkube
@@ -115,7 +115,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Restore cache .m2 and JKube
-        uses: actions/cache@v2
+        uses: actions/cache@69d9d449aced6a2ede0bc19182fadc3a0a42d2b0
         with:
           path: |
             ${{ github.workspace }}/jkube


### PR DESCRIPTION


Related to https://github.com/jkubeio/jkube-integration-tests/issues/243

Upgrade actions/cache to latest revision that contains fix related to zstd